### PR TITLE
feat: add savings group data structures, creation, and membership system

### DIFF
--- a/src/base/errors.cairo
+++ b/src/base/errors.cairo
@@ -20,3 +20,18 @@ pub mod ERC20Errors {
     /// Error triggered when the caller is not the owner of the token
     pub const NotAdmin: felt252 = 'ERC20: not admin';
 }
+
+
+pub mod GroupsErrors {
+    /// Error triggered when the max members is less than two
+    pub const INVALID_GROUP_SIZE: felt252 = 'GROUP: mini 2 members expected';
+
+    /// Error triggered when trying to join an inactive group
+    pub const GROUP_INACTIVE: felt252 = 'GROUP: group is inactive';
+
+    /// Error triggered when trying to join a group twice
+    pub const ALREADY_MEMBER: felt252 = 'GROUP: caller already a member';
+
+    /// Error triggered when the group is full
+    pub const GROUP_FULL: felt252 = 'GROUP: group is full';
+}

--- a/src/interfaces/IGroups.cairo
+++ b/src/interfaces/IGroups.cairo
@@ -1,0 +1,5 @@
+#[starknet::interface]
+pub trait IGroups<TContractState> {
+    fn create_group(ref self: TContractState, max_members: u8) -> u64;
+    fn join_group(ref self: TContractState, group_id: u64);
+}

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -5,6 +5,7 @@ pub mod base {
 
 pub mod interfaces {
     pub mod IERC20;
+    pub mod IGroups;
     pub mod IStarkRemit;
 }
 


### PR DESCRIPTION
## Description

This PR implements the savings group data structure, group creation, and membership system as outlined in #19.

# Changes

- **Data model**
  - In `types.cairo`:
    - Added `SavingsGroup` struct with fields: `id`, `creator`, `max_members`, `member_count`, `is_active`
  - Updated contract storage with:
    - `groups`: maps `group_id` → `SavingsGroup`
    - `group_members`: flags membership per (`group_id`, `address`)
    - `group_count`: tracks total number of groups. Used to generate unique group id

- **Functions**
  - `create_group(max_members: u8) -> u64`:
    - Requires caller to be registered and KYC-approved
    - Requires `max_members > 1`
    - Generates a new group ID
    - Stores group with caller as first member
    - Emits `GroupCreated` event
  - `join_group(group_id: u64)`:
    - Requires caller to be registered and KYC-approved
    - Validates group is active, caller is not already a member, and group is not full
    - Updates membership state
    - Emits `MemberJoined` event
  - `_new_group_id()` internal helper that returns and increments `group_count`

- **Error handling**
  - In `errors.cairo`:
    - Created `GroupErrors` that hold error messages

- **Events**
  - Added `GroupCreated` and `MemberJoined` events

## Design Choices

- `group_members` is stored in the main storage instead of inside `SavingsGroup` to avoid declaring the struct as `#[starknet::storage_node]`. This way, we can store and load the entire `SavingsGroup` struct in one operation instead of updating fields individually.
